### PR TITLE
[Step 6] ERD, API 명세서, Mock API, 패키지 구조 작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@
 
 - [시퀀스 다이어그램](docs/sequence_diagram.md)
 - [ERD](docs/erd.md)
+- [API 명세서](docs/api_specification.md)

--- a/README.md
+++ b/README.md
@@ -10,3 +10,53 @@
 - [시퀀스 다이어그램](docs/sequence_diagram.md)
 - [ERD](docs/erd.md)
 - [API 명세서](docs/api_specification.md)
+
+<br/>
+
+## 패키지 구조
+
+```
+hhplus
+    └── concertreservation
+        ├── interfaces       # 외부 인터페이스 (Controller, API 등)
+        │   └── api          # 도메인별 API
+        │       ├── concert  # 콘서트 관련 API 및 사용자 요청 처리 (Controller)
+        │       ├── payment  # 결제 관련 API (Controller)
+        │       ├── queue    # 유저 대기열 관련 API (Controller)
+        │       ├── token    # 토큰 관련 API (Controller)
+        │       └── user     # 사용자 관련 API 및 인증, 등록 처리 (Controller)
+        │   
+        ├── application      # 비즈니스 로직을 처리하는 유스케이스(Use Case) 계층
+        │   ├── concert      # 콘서트 비즈니스 로직 처리 (Facade)
+        │   ├── payment      # 결제 로직 처리 (Facade)               
+        │   ├── tokenQueue   # 토큰 대기열 관련 로직 처리 (Facade)
+        │   └── user         # 사용자 관련 비즈니스 로직 처리 (Facade)
+        │   
+        ├── domain           # 핵심 비즈니스 로직
+        │   ├── concert      # 콘서트 관련 도메인 객체 및 비즈니스 규칙 정의 (Service, Entity, Repository)
+        │   ├── payment      # 결제 관련 도메인 객체 및 트랜잭션 관리 규칙 정의 (Service, Entity, Repository)
+        │   ├── reservation  # 예약 관련 도메인 객체 및 비즈니스 규칙 정의 (Service, Entity, Repository)
+        │   ├── tokenQueue   # 토큰 대기열 관련 도메인 객체 및 비즈니스 규칙 정의 (Service, Entity, Repository)
+        │   └── user         # 사용자 관련 도메인 객체 및 비즈니스 규칙 정의 (Service, Entity, Repository)
+        │   
+        └── infrastructure   # 외부 시스템과의 통신 (DB, MQ 등)
+            ├── concert      # 콘서트 정보 저장 및 조회 시스템 연동
+            ├── payment      # 결제 시스템 연동
+            ├── queue        # 대기열 관리를 위한 인프라 연동
+            ├── reservation  # 예약 정보 저장 및 처리 관련 인프라 연동
+            └── user         # 사용자 정보 저장 및 조회 시스템 연동
+
+```
+
+<br/>
+
+## 기술 스택
+
+- **Language**: Kotlin
+- **Framework**: Spring Boot
+- **Database**: H2
+- **Build Tool**: Gradle
+- **Test Framework**: JUnit 5
+
+
+<br/><br/>

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 ## 문서
 
 - [시퀀스 다이어그램](docs/sequence_diagram.md)
+- [ERD](docs/erd.md)

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -38,7 +38,7 @@ Content-Type: application/json;charset=UTF-8
 **Response Body 예시**
 
 ```json
-HTTP/1.1 200 OK
+HTTP/1.1 201 CREATED
 Content-Type: application/json;charset=UTF-8
 {
     "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -204,9 +204,9 @@ HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 {
     "seats": [
-        {"seat_number": "A1", "status": "available"},
-        {"seat_number": "A2", "status": "available"},
-        {"seat_number": "A3", "status": "reserved"}
+        {"seatNumber": "A1", "status": "available"},
+        {"seatNumber": "A2", "status": "available"},
+        {"seatNumber": "A3", "status": "reserved"}
     ]
 }
 ```
@@ -268,7 +268,7 @@ Content-Type: application/json;charset=UTF-8
 **Response Body 예시**
 
 ```json
-HTTP/1.1 200 OK
+HTTP/1.1 201 CREATED
 Content-Type: application/json;charset=UTF-8
 {
     "status": "success"
@@ -331,7 +331,7 @@ Content-Type: application/json;charset=UTF-8
 **Response Body 예시**
 
 ```json
-HTTP/1.1 200 OK
+HTTP/1.1 201 CREATED
 Content-Type: application/json;charset=UTF-8
 {
     "status": "success"
@@ -429,7 +429,7 @@ POST /api/payment
 Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 Content-Type: application/json;charset=UTF-8
 {
-    "user_id": 1,
+    "userId": 1,
     "amount": 10000
 }
 ```
@@ -443,7 +443,7 @@ Content-Type: application/json;charset=UTF-8
 **Response Body 예시**
 
 ```json
-HTTP/1.1 200 OK
+HTTP/1.1 201 CREATED
 Content-Type: application/json;charset=UTF-8
 {
     "status": "success"
@@ -477,7 +477,7 @@ Content-Type: application/json;charset=UTF-8
 **Request 예시**
 
 ```json
-GET /api/users/1/payments
+GET /api/user/1/payments
 ```
 
 **Response**

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -32,7 +32,7 @@ Content-Type: application/json;charset=UTF-8
 
 | 이름 | 타입 | 설명 |
 | --- | --- | --- |
-| token | String | 콘서트 일정 ID |
+| token | String | 토큰 (UUID) |
 | status | String | 응답 상태 ("issued", "existing") |
 
 **Response Body 예시**

--- a/docs/api_specification.md
+++ b/docs/api_specification.md
@@ -1,0 +1,528 @@
+## API 명세서
+
+<br/>
+
+### 1. **유저 토큰 발급 API**
+
+- **설명**: 유저가 콘서트 예약 대기열 진입에 대한 토큰을 발급받는 API
+- **HTTP Method**: `POST`
+- **URL**: `/api/token`
+
+**Request**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| concertId | Integer | 콘서트 ID |
+| concertScheduleId | Integer | 콘서트 일정 ID |
+| userId | Integer | 유저 ID |
+
+**Request 예시**
+
+```json
+POST /api/token
+Content-Type: application/json;charset=UTF-8
+{
+    "concertId": 2,
+    "concertScheduleId": 5,
+    "userId": 1
+}
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| token | String | 콘서트 일정 ID |
+| status | String | 응답 상태 ("issued", "existing") |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+    "status": "issued"
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (필수 필드 누락 또는 형식 오류) |
+| 401 | 인증 실패 (유효하지 않은 유저 ID) |
+| 404 | 콘서트 또는 콘서트 일정 ID가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 2. **대기열 조회 API**
+
+- **설명**: 유저가 자신의 대기열 상태를 조회하는 API
+- **HTTP Method**: `GET`
+- **URL**: `/api/queue`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| token | String | 유저 대기열 토큰 |
+
+**Request 예시**
+
+```json
+GET /api/queue
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| status | String | 현재 대기열 상태 ("waiting", "active") |
+| queuePosition | String | 대기 중일 때, 현재 대기열 순번 |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "status": "waiting",
+    "queuePosition": 10
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식) |
+| 404 | 대기열에 해당 유저가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 3. **예약 가능 날짜 조회 API**
+
+- **설명**: 유저가 특정 콘서트에 대해 예약 가능한 날짜 목록을 조회하는 API
+- **HTTP Method**: `GET`
+- **URL**: `/api/concert/{concertId}/available`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| Queue-Token | String | 유저 대기열 토큰 |
+
+**Path Parameters**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| concertId | Integer | 콘서트 ID |
+
+**Request 예시**
+
+```json
+GET /api/concert/2/available
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| dates | List | 예약 가능한 날짜 목록 |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "dates": [
+        "2024-10-05T19:00:00",
+        "2024-10-06T19:00:00",
+        "2024-10-07T19:00:00"
+    ]
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식) |
+| 404 | 콘서트가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 4. **예약 가능 날짜에 대한 좌석 조회 API**
+
+- **설명**: 유저가 특정 콘서트의 예약 가능한 해당 날짜에 대해 예약 가능한 좌석 목록을 조회하는 API
+- **HTTP Method**: `GET`
+- **URL**: `/api/concert/{concertId}/schedule/{scheduleId}/available`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| Queue-Token | String | 유저 대기열 토큰 |
+
+**Path Parameters**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| concertId | Integer | 콘서트 ID |
+| scheduleId | Integer | 콘서트 일정 ID |
+
+**Request 예시**
+
+```json
+GET /api/concert/2/schedule/3/available
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| seats | List | 예약 가능한 좌석 목록 |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "seats": [
+        {"seat_number": "A1", "status": "available"},
+        {"seat_number": "A2", "status": "available"},
+        {"seat_number": "A3", "status": "reserved"}
+    ]
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식) |
+| 404 | 콘서트 or 콘서트 일정이 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 5. **좌석 예약 요청 API**
+
+- **설명**: 유저가 콘서트의 예약 가능한 좌석을 예약하는 API
+- **HTTP Method**: `POST`
+- **URL**: `/api/concert/{concertId}/schedule/{scheduleId}/reserve`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| Queue-Token | String | 유저 대기열 토큰 |
+
+**Request Body**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| seatId | Integer | 예약할 좌석 ID |
+
+**Path Parameters**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| concertId | Integer | 콘서트 ID |
+| scheduleId | Integer | 콘서트 일정 ID |
+
+**Request 예시**
+
+```json
+POST /api/concert/2/schedule/3/reserve
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Content-Type: application/json;charset=UTF-8
+{
+    "seatId": 7
+}
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| status | String | 요청 처리 결과 (예: "success", "invalid_token", "invalid_concert", "invalid_date", "seat_already_reserved") |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "status": "success"
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식) |
+| 404 | 콘서트 or 콘서트 일정 or 좌석이 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 6. **잔액 충전 API**
+
+- **설명**: 유저가 잔액을 충전하는 API
+- **HTTP Method**: `POST`
+- **URL**: `/api/user/{userId}/charge`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| Queue-Token | String | 유저 대기열 토큰 |
+
+**Request Body**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| amount | Integer | 충전할 금액 |
+
+**Path Parameters**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| userId | Integer | 유저 ID |
+
+**Request 예시**
+
+```json
+POST /api/user/1/charge
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Content-Type: application/json;charset=UTF-8
+{
+    "amount": 10000
+}
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| status | String | 요청 처리 결과 (예: "success", “failed”) |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "status": "success"
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식 또는 충전 금액) |
+| 404 | 유저가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 7. **잔액 조회 API**
+
+- **설명**: 유저의 현재 잔액을 조회하는 API
+- **HTTP Method**: `GET`
+- **URL**: `/api/user/{userId}/balance`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| Queue-Token | String | 유저 대기열 토큰 |
+
+**Path Parameters**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| userId | Integer | 유저 ID |
+
+**Request 예시**
+
+```json
+GET /api/user/1/balance
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| balance | Integer | 잔액 |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "balance": 50000
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식) |
+| 404 | 유저가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 8. **결제 API**
+
+- **설명**: 유저가 예약한 좌석에 대해 결제를 진행하는 API
+- **HTTP Method**: `POST`
+- **URL**: `/api/payment`
+
+**Request Header**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| Queue-Token | String | 유저 대기열 토큰 |
+
+**Request Body**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| userId | Integer | 유저 ID |
+| amount | Integer | 결제 금액 |
+
+**Request 예시**
+
+```json
+POST /api/payment
+Queue-Token: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Content-Type: application/json;charset=UTF-8
+{
+    "user_id": 1,
+    "amount": 10000
+}
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| status | Integer | 결제 처리 결과 (예: "success", “payment_failed”, “insufficient_balance”) |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+    "status": "success"
+}
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 400 | 요청 값이 잘못된 경우 (유효하지 않은 토큰 형식) |
+| 404 | 유저가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>
+
+---
+
+### 9. **결제 내역 조회 API**
+
+- **설명**: 유저의 결제 내역을 조회하는 API
+- **HTTP Method**: `GET`
+- **URL**: `/api/user/{user_id}/payments`
+
+**Path Parameters**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| userId | Integer | 유저 ID |
+
+**Request 예시**
+
+```json
+GET /api/users/1/payments
+```
+
+**Response**
+
+| 이름 | 타입 | 설명 |
+| --- | --- | --- |
+| id | Integer | 결제 ID |
+| title | String | 콘서트 이름 |
+| time | String | 콘서트 일시 |
+| seatNumber | String | 콘서트 예약 좌석 번호 |
+| price | Integer | 콘서트 티켓 가격 |
+| status | String | 결제 상태 ("success", “canceled”) |
+
+**Response Body 예시**
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+{
+  "payments": [
+    {
+      "id": 3,
+      "title": "BTS 월드 투어",
+      "time": "2024-10-05T19:00:00",
+      "seatNumber": "A1",
+      "price": 110000,
+      "status": "success"
+    },
+    {
+      "id": 4,
+      "title": "IU 상암 콘서트",
+      "time": "2024-10-10T19:00:00",
+      "seatNumber": "B16",
+      "price": 90000,
+      "status": "success"
+    }
+  ]
+}  
+```
+
+**에러 코드**
+
+| HTTP 상태 코드 | 설명 |
+| --- | --- |
+| 404 | 유저가 존재하지 않는 경우 |
+| 500 | 서버 내부 오류 |
+
+<br/><br/><br/>

--- a/docs/erd.md
+++ b/docs/erd.md
@@ -1,0 +1,130 @@
+## ER 다이어그램
+
+<br/>
+
+```mermaid
+erDiagram
+    USER {
+    INT id PK "유저 ID"
+    VARCHAR name "이름"
+    VARCHAR email "이메일"
+    DECIMAL balance "잔액"
+    TIMESTAMP created_at "생성일시"
+    TIMESTAMP updated_at "수정일시"
+    }
+
+    POINT_HISTORY {
+        INT id PK "포인트 내역 ID"
+        INT user_id FK "유저 ID"
+        DECIMAL amount "변동 금액"
+        VARCHAR type "유형(충전, 사용)"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+    }
+
+    CONCERT {
+        INT id PK "콘서트 ID"
+        VARCHAR title "콘서트 이름"
+        TIME duration "콘서트 시간"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+    }
+
+    CONCERT_SCHEDULE {
+        INT id PK "일정 ID"
+        INT concert_id FK "콘서트 ID"
+        TIMESTAMP start_time "콘서트 일시"
+        INT total_seats "총 좌석수"
+        INT available_seats "예약 가능 좌석수"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+    }
+
+    SEAT {
+        INT id PK "좌석 ID"
+        INT schedule_id FK "일정 ID"
+        VARCHAR seat_number "좌석 번호"
+        DECIMAL price "좌석 가격"
+        VARCHAR status "상태(가능, 불가)"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+    }
+
+    RESERVATION {
+        INT id PK "예약 ID"
+        INT user_id FK "유저 ID"
+        INT schedule_id FK "일정 ID"
+        INT seat_id FK "좌석 ID"
+        VARCHAR status "상태(임시, 확정, 취소)" 
+		TIMESTAMP expires_at "임시 예약 만료 시간"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+    }
+
+    PAYMENT {
+        INT id PK "결제 ID"
+        INT user_id FK "유저 ID"
+        DECIMAL amount "결제 금액"
+        VARCHAR status "상태 (성공, 실패, 취소)" 
+        INT reservation_id FK "예약 ID"
+        TIMESTAMP created_at "생성일시"
+        TIMESTAMP updated_at "수정일시"
+    }
+
+    TOKEN_QUEUE {
+        INT id PK "ID"
+        INT user_id FK "유저 ID"
+        INT schedule_id FK "일정 ID"
+        VARCHAR token "토큰"
+        VARCHAR status "상태 (대기, 활성, 만료)"
+        TIMESTAMP expires_at "토큰 만료 시간"
+        INT queue_position "대기열 순번"
+        TIMESTAMP created_at "생성 시간"
+        TIMESTAMP updated_at "수정 시간"
+    }
+
+    USER ||--o{ POINT_HISTORY : ""
+    USER ||--o{ RESERVATION : ""
+    USER ||--o{ PAYMENT : ""
+    USER ||--o{ TOKEN_QUEUE : ""
+
+    CONCERT ||--o{ CONCERT_SCHEDULE : ""
+    CONCERT_SCHEDULE ||--o{ SEAT : ""
+    CONCERT_SCHEDULE ||--o{ RESERVATION : ""
+    SEAT ||--o{ RESERVATION : ""
+    RESERVATION ||--o{ PAYMENT : ""
+```
+
+<br/><br/>
+
+### ERD 설계 흐름
+
+#### 1. `user` 테이블에 `잔액(balance)` 필드 추가
+
+- 포인트 이력 테이블을 기반으로 잔액을 계산하는 방식 대신, 충전과 사용 시 `user` 테이블의 잔액 필드도 함께 수정하도록 하였습니다. 잔액 조회 시에 발생할 수 있는 성능 저하를 방지하고 보다 효율적인 조회가 가능하도록 작성했습니다.
+
+#### 2. 콘서트의 회차별 정보를 저장하는 `concert_schedule` 테이블 작성
+
+- `concert` 테이블과 1:N 관계로 각 콘서트의 회차 별 정보 (일시, 좌석 수 등)을 관리하는 테이블을 작성함으로써 독립적으로 관리할 수 있도록 설계했습니다.
+
+#### 3. 좌석 정보를 저장하는 `seat` 테이블 작성
+
+- 각 콘서트 회차에서 개별 좌석에 대한 정보를 관리하는 테이블을 작성했습니다. 유저 입장에서 좌석은 예약 가능 여부가 중요하다 판단되어, 임시 배정에 대한 상태를 `seat` 테이블 대신 `reservation` 테이블에 기록하도록 설계했습니다.
+
+#### 4. `concert_schedule` 테이블에 `available_seats` 필드 추가
+
+- 좌석 수를 실시간으로 `seat` 테이블에서 `COUNT(*)`를 통해 계산하지 않고, 예약 가능 좌석 수를 바로 조회할 수 있도록 `concert_schedule` 테이블에 `available_seats` 필드를 추가하였습니다. 이 부분도 좌석 수 조회 시 성능을 개선하기 위해 작성했습니다.
+
+#### 5. `token_queue` 테이블로 콘서트 일정 별 대기열 구현
+
+- 대기열을 구현하기 위해 `token_queue` 테이블을 작성하였습니다. 각 콘서트 일정마다 대기열 상태를 관리하며, `token` 필드에 인덱스를 적용하여 토큰을 가지고 대기열 상태 및 만료 시간을 조회하는 성능을 높여서 유저가 자신의 대기 상태를 빠르게 확인할 수 있도록 하였습니다.
+
+#### 6. `seat` 테이블과 `reservation` 테이블을 분리하여 관리
+
+- 좌석과 예약 정보를 구분하기 위해 `seat` 테이블과 `reservation` 테이블을 나누었습니다. 이를 통해 좌석에 대한 `임시 예약`, `확정 예약`, `취소` 상태를 명확하게 관리할 수 있도록 하였습니다. 좌석 상태를 독립적으로 관리하여 예약의 상태 변화에 따른 영향을 최소화 했습니다.
+
+#### 7. 임시 배정 해제를 위한 `expires_at` 필드 추가
+
+- 좌석의 임시 배정에 대한 자동 해제 기능을 구현하기 위해 `reservation` 테이블에 `expires_at` 필드를 추가하였습니다. 이를 통해 해당 시간이 지나면 임시 배정이 자동으로 만료되도록 하는 요구사항을 반영하도록 작성했습니다.
+
+<br/><br/>

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/ConcertController.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/ConcertController.kt
@@ -1,0 +1,55 @@
+package hhplus.concertreservation.interfaces.api.concert
+
+import hhplus.concertreservation.interfaces.api.concert.dto.req.ReserveSeatRequest
+import hhplus.concertreservation.interfaces.api.concert.dto.res.AvailableDatesResponse
+import hhplus.concertreservation.interfaces.api.concert.dto.res.AvailableSeatsResponse
+import hhplus.concertreservation.interfaces.api.concert.dto.res.ReserveSeatResponse
+import hhplus.concertreservation.interfaces.api.concert.dto.res.SeatResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/concert")
+class ConcertController {
+
+    @GetMapping("/{concertId}/available")
+    fun getAvailableDates(
+        @PathVariable concertId: Int,
+        @RequestHeader("Queue-Token") token: String
+    ): ResponseEntity<AvailableDatesResponse> {
+        val availableDates = listOf(
+            "2024-10-05T19:00:00",
+            "2024-10-06T19:00:00",
+            "2024-10-07T19:00:00"
+        )
+        return ResponseEntity.ok(
+            AvailableDatesResponse(dates = availableDates)
+        )
+    }
+
+    @GetMapping("/{concertId}/schedule/{scheduleId}/available")
+    fun getAvailableSeats(
+        @PathVariable concertId: Int,
+        @PathVariable scheduleId: Int,
+        @RequestHeader("Queue-Token") token: String
+    ): ResponseEntity<AvailableSeatsResponse> {
+        val availableSeats = listOf(
+            SeatResponse(seatNumber = "A1", status = "available"),
+            SeatResponse(seatNumber = "A2", status = "available"),
+            SeatResponse(seatNumber = "A3", status = "reserved"),
+        )
+        return ResponseEntity.ok(AvailableSeatsResponse(seats = availableSeats))
+    }
+
+    @PostMapping("/{concertId}/schedule/{scheduleId}/reserve")
+    fun reserveSeat(
+        @PathVariable concertId: Int,
+        @PathVariable scheduleId: Int,
+        @RequestHeader("Queue-Token") token: String,
+        @RequestBody request: ReserveSeatRequest
+    ): ResponseEntity<ReserveSeatResponse> {
+        return ResponseEntity.ok(
+            ReserveSeatResponse(status = "success")
+        )
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/req/ReserveSeatRequest.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/req/ReserveSeatRequest.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.concert.dto.req
+
+data class ReserveSeatRequest(
+    val seatId: Long,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/res/AvailableDatesResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/res/AvailableDatesResponse.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.concert.dto.res
+
+data class AvailableDatesResponse(
+    val dates: List<String>
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/res/AvailableSeatsResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/res/AvailableSeatsResponse.kt
@@ -1,0 +1,10 @@
+package hhplus.concertreservation.interfaces.api.concert.dto.res
+
+data class AvailableSeatsResponse(
+    val seats: List<SeatResponse>
+)
+
+data class SeatResponse(
+    val seatNumber: String,
+    val status: String,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/res/ReserveSeatResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/concert/dto/res/ReserveSeatResponse.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.concert.dto.res
+
+data class ReserveSeatResponse(
+    val status: String,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/payment/PaymentController.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/payment/PaymentController.kt
@@ -1,0 +1,20 @@
+package hhplus.concertreservation.interfaces.api.payment
+
+import hhplus.concertreservation.interfaces.api.payment.dto.req.PaymentRequest
+import hhplus.concertreservation.interfaces.api.payment.dto.res.PaymentResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/payment")
+class PaymentController {
+
+    @PostMapping
+    fun processPayment(
+        @RequestHeader("Queue-Token") token: String,
+        @RequestBody request: PaymentRequest
+    ): ResponseEntity<PaymentResponse> {
+        val response = PaymentResponse(status = "success")
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/payment/dto/req/PaymentRequest.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/payment/dto/req/PaymentRequest.kt
@@ -1,0 +1,6 @@
+package hhplus.concertreservation.interfaces.api.payment.dto.req
+
+data class PaymentRequest(
+    val userId: Long,
+    val amount: Int,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/payment/dto/res/PaymentResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/payment/dto/res/PaymentResponse.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.payment.dto.res
+
+data class PaymentResponse(
+    val status: String,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/queue/QueueController.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/queue/QueueController.kt
@@ -1,0 +1,22 @@
+package hhplus.concertreservation.interfaces.api.queue
+
+import hhplus.concertreservation.interfaces.api.queue.dto.res.QueueResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/queue")
+class QueueController {
+
+    @GetMapping
+    fun getQueueStatus(
+        @RequestHeader("Queue-Token") token: String,
+    ): ResponseEntity<QueueResponse> {
+        return ResponseEntity.ok(
+            QueueResponse(
+                status = "waiting",
+                queuePosition = "10",
+            )
+        )
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/queue/dto/res/QueueResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/queue/dto/res/QueueResponse.kt
@@ -1,0 +1,6 @@
+package hhplus.concertreservation.interfaces.api.queue.dto.res
+
+data class QueueResponse(
+    val status: String,
+    val queuePosition: String?,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/token/TokenController.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/token/TokenController.kt
@@ -1,0 +1,27 @@
+package hhplus.concertreservation.interfaces.api.token
+
+import hhplus.concertreservation.interfaces.api.token.dto.req.TokenRequest
+import hhplus.concertreservation.interfaces.api.token.dto.res.TokenResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/token")
+class TokenController {
+
+    @PostMapping
+    fun issueToken(
+        @RequestBody request: TokenRequest,
+    ): ResponseEntity<TokenResponse> {
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+            TokenResponse(
+                token= "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+                status = "issued",
+            )
+        )
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/token/dto/req/TokenRequest.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/token/dto/req/TokenRequest.kt
@@ -1,0 +1,7 @@
+package hhplus.concertreservation.interfaces.api.token.dto.req
+
+data class TokenRequest(
+    val concertId: Long,
+    val concertScheduleId: Long,
+    val userId: Long,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/token/dto/res/TokenResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/token/dto/res/TokenResponse.kt
@@ -1,0 +1,6 @@
+package hhplus.concertreservation.interfaces.api.token.dto.res
+
+data class TokenResponse(
+    val token: String,
+    val status: String,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/UserController.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/UserController.kt
@@ -1,0 +1,47 @@
+package hhplus.concertreservation.interfaces.api.user
+
+import hhplus.concertreservation.interfaces.api.user.dto.req.ChargeBalanceRequest
+import hhplus.concertreservation.interfaces.api.user.dto.res.BalanceResponse
+import hhplus.concertreservation.interfaces.api.user.dto.res.ChargeBalanceResponse
+import hhplus.concertreservation.interfaces.api.user.dto.res.PaymentDetail
+import hhplus.concertreservation.interfaces.api.user.dto.res.PaymentHistoryResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/user")
+class UserController {
+
+    @PostMapping("/{userId}/charge")
+    fun chargeBalance(
+        @PathVariable userId: Int,
+        @RequestHeader("Queue-Token") token: String,
+        @RequestBody request: ChargeBalanceRequest
+    ): ResponseEntity<ChargeBalanceResponse> {
+        return ResponseEntity.ok(
+            ChargeBalanceResponse(status = "success")
+        )
+    }
+
+    @GetMapping("/{userId}/balance")
+    fun getBalance(
+        @PathVariable userId: Int,
+        @RequestHeader("Queue-Token") token: String
+    ): ResponseEntity<BalanceResponse> {
+        return ResponseEntity.ok(
+            BalanceResponse(balance = 50000)
+        )
+    }
+
+    @GetMapping("/{userId}/payments")
+    fun getPaymentHistory(
+        @PathVariable userId: Int
+    ): ResponseEntity<PaymentHistoryResponse> {
+        val payments = listOf(
+            PaymentDetail(id = 3, title = "BTS 월드 투어", time = "2024-10-05T19:00:00", seatNumber = "A1", price = 110000, status = "success"),
+            PaymentDetail(id = 4, title = "IU 상암 콘서트", time = "2024-10-10T19:00:00", seatNumber = "B16", price = 90000, status = "success")
+        )
+        val response = PaymentHistoryResponse(payments = payments)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/req/ChargeBalanceRequest.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/req/ChargeBalanceRequest.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.user.dto.req
+
+data class ChargeBalanceRequest(
+    val amount: Int,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/res/BalanceResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/res/BalanceResponse.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.user.dto.res
+
+data class BalanceResponse(
+    val balance: Int,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/res/ChargeBalanceResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/res/ChargeBalanceResponse.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.interfaces.api.user.dto.res
+
+data class ChargeBalanceResponse(
+    val status: String,
+)

--- a/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/res/PaymentHistoryResponse.kt
+++ b/src/main/kotlin/hhplus/concertreservation/interfaces/api/user/dto/res/PaymentHistoryResponse.kt
@@ -1,0 +1,14 @@
+package hhplus.concertreservation.interfaces.api.user.dto.res
+
+data class PaymentHistoryResponse(
+    val payments: List<PaymentDetail>
+)
+
+data class PaymentDetail(
+    val id: Long,
+    val title: String,
+    val time: String,
+    val seatNumber: String,
+    val price: Int,
+    val status: String,
+)


### PR DESCRIPTION
## 작업 내역

1. ERD 설계
2. API 명세 및 Mock API 작성
3. 패키지 구조 작성

<br/>

## 의사결정 흐름

### 1. **ERD 설계**
   - 유저, 콘서트, 대기열, 결제 등의 도메인 관계를 명확히 하기 위해 ERD을 통해 필드를 정의하고 관계를 설정했습니다. ERD를 설계하는 의사결정 흐름에 대해 `erd.md`에 작성해놓았습니다.
### 2. **API 명세 작성**
   - Restful한 API 를 위해 고민하며 작성했습니다. 하위 구조로 되어있는 엔티티에 대한 요청 URL 설정을 특히 고민하였고, 미리 예시를 작성함으로써 Mock API를 만들 때 더 빠르게 작성할 수 있었습니다.
### 3. **Mock API**
   - API 명세를 바탕으로 Mock API를 구현하여 클라이언트와 미리 테스트해볼 수 있는 환경을 구축했습니다. API 별 요청, 응답 객체를 만들어 데이터를 주고 받을 수 있도록 작성했습니다.

<br/>

## 리뷰 포인트

1. **`concert_schedule` 테이블의 `예약 가능 좌석 수(available_seats)` 필드**  

    - 빠른 조회를 위해 `concert_schedule` 테이블에 `available_seats` 컬럼을 추가하여 해당 콘서트 일정이 예약 가능한 좌석 수를 저장하고 있지만, 좌석 상태 변화에 따라 `available_seats`를 동기화하는 로직이 필요합니다. 이 과정에서 락이 걸릴 경우 콘서트 스케줄 조회에 영향을 줄 수 있을 것 같은데, 이러한 동기화 과정에서 발생할 수 있는 문제를 기술적으로 풀려면 어떻게 해결할 수 있을까요? 아래 생각나는 방법 이외의 방법들이 궁금합니다. 그리고 코치님이 생각하기에 최선의 선택지는 무엇이라 생각하시는지도 궁금합니다!
    
    - **생각나는 해결 방법** 
     1. 해당 필드를 별도의 테이블로 분리하여 정규화
     2. 필드를 삭제하고 매번 `seat` 테이블 count 한다
     3. 이벤트 소싱으로 최종 일관성을 지키게끔 한다


2. **`대기열(Queue)`을 도메인으로 봐야 할까요?**

    - 이번 과제를 진행하면서 `대기열`이라는 개념이 등장했는데, 패키지 구조를 설계할 때 고민이 생겼습니다. `대기열(Queue)`을 비즈니스 로직 관점에서 하나의 도메인으로 봐야 할지, 아니면 단순히 비즈니스 로직을 처리하기 위한 `수단`으로 생각해서 도메인으로 설정하지 않아야 하는지 고민됩니다. 이 부분에 대해 어떻게 접근하는 게 좋을지 궁금합니다.
    - 만약 대기열을 도메인에 포함하지 않는다면 Application 계층에서 대기열 관련 매니저를 작성하고 Infrastructure 계층의 외부 대기열 시스템을 사용하는 방식으로 구현해도 될지도 궁금합니다.
 