### PR TITLE
[Step 16] 이벤트 기반 트랜잭션 분리 설계에 관한 문서 작성과 외부 데이터 플랫폼 이벤트 처리 로직 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Chapter 2 중간 회고록](https://eastshine12.tistory.com/67)
 - [동시성 제어 방식 비교 및 성능 테스트](https://eastshine12.tistory.com/68)
 - [Redis 기반의 캐싱 및 대기열 관리를 통한 콘서트 예약 서비스 성능 개선](https://eastshine12.tistory.com/69)
+- [서비스 확장을 위한 트랜잭션 분리와 이벤트 기반 설계](https://eastshine12.tistory.com/71)
 
 <br/>
 

--- a/src/main/kotlin/hhplus/concertreservation/config/AsyncConfig.kt
+++ b/src/main/kotlin/hhplus/concertreservation/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package hhplus.concertreservation.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@EnableAsync
+@Configuration
+class AsyncConfig

--- a/src/main/kotlin/hhplus/concertreservation/domain/concert/event/ReservationCreatedEvent.kt
+++ b/src/main/kotlin/hhplus/concertreservation/domain/concert/event/ReservationCreatedEvent.kt
@@ -1,0 +1,21 @@
+package hhplus.concertreservation.domain.concert.event
+
+import hhplus.concertreservation.domain.concert.entity.Reservation
+
+data class ReservationCreatedEvent(
+    val userId: Long,
+    val scheduleId: Long,
+    val seatId: Long,
+    val reservationId: Long,
+) {
+    companion object {
+        fun from(reservation: Reservation): ReservationCreatedEvent {
+            return ReservationCreatedEvent(
+                userId = reservation.userId,
+                scheduleId = reservation.scheduleId,
+                seatId = reservation.seatId,
+                reservationId = reservation.id,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/domain/concert/service/ReservationService.kt
+++ b/src/main/kotlin/hhplus/concertreservation/domain/concert/service/ReservationService.kt
@@ -5,9 +5,11 @@ import hhplus.concertreservation.domain.concert.component.SeatFinder
 import hhplus.concertreservation.domain.concert.dto.info.CreateReservationInfo
 import hhplus.concertreservation.domain.concert.dto.info.ReservationInfo
 import hhplus.concertreservation.domain.concert.entity.Reservation
+import hhplus.concertreservation.domain.concert.event.ReservationCreatedEvent
 import hhplus.concertreservation.domain.concert.repository.ReservationRepository
 import hhplus.concertreservation.domain.concert.toCreateReservationInfo
 import hhplus.concertreservation.domain.concert.toReservationInfo
+import hhplus.concertreservation.infrastructure.event.EventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -17,6 +19,7 @@ class ReservationService(
     private val seatFinder: SeatFinder,
     private val concertManager: ConcertManager,
     private val reservationRepository: ReservationRepository,
+    private val eventPublisher: EventPublisher<ReservationCreatedEvent>,
 ) {
     @Transactional
     fun createPendingReservation(
@@ -27,6 +30,7 @@ class ReservationService(
         seatFinder.getAvailableSeat(scheduleId, seatId).reserve()
         occupySeat(scheduleId)
         val reservation = concertManager.createPendingReservation(userId, scheduleId, seatId)
+        eventPublisher.publish(ReservationCreatedEvent.from(reservation))
         return reservation.toCreateReservationInfo(success = true)
     }
 

--- a/src/main/kotlin/hhplus/concertreservation/infrastructure/api/DataPlatformApiClient.kt
+++ b/src/main/kotlin/hhplus/concertreservation/infrastructure/api/DataPlatformApiClient.kt
@@ -1,0 +1,12 @@
+package hhplus.concertreservation.infrastructure.api
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class DataPlatformApiClient {
+    private val log = LoggerFactory.getLogger(this::class.java)
+    fun sendReservation() {
+        log.info("외부 API 호출: 예약 전송 이벤트 처리 완료")
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/infrastructure/event/EventListener.kt
+++ b/src/main/kotlin/hhplus/concertreservation/infrastructure/event/EventListener.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.infrastructure.event
+
+interface EventListener<T> {
+    fun handle(event: T)
+}

--- a/src/main/kotlin/hhplus/concertreservation/infrastructure/event/EventPublisher.kt
+++ b/src/main/kotlin/hhplus/concertreservation/infrastructure/event/EventPublisher.kt
@@ -1,0 +1,5 @@
+package hhplus.concertreservation.infrastructure.event
+
+interface EventPublisher<T> {
+    fun publish(event: T)
+}

--- a/src/main/kotlin/hhplus/concertreservation/infrastructure/event/listener/ExternalPlatformEventListener.kt
+++ b/src/main/kotlin/hhplus/concertreservation/infrastructure/event/listener/ExternalPlatformEventListener.kt
@@ -1,0 +1,23 @@
+package hhplus.concertreservation.infrastructure.event.listener
+
+import hhplus.concertreservation.domain.concert.event.ReservationCreatedEvent
+import hhplus.concertreservation.infrastructure.api.DataPlatformApiClient
+import hhplus.concertreservation.infrastructure.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ExternalPlatformEventListener(
+    private val dataPlatformApiClient: DataPlatformApiClient
+): EventListener<ReservationCreatedEvent> {
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    override fun handle(event: ReservationCreatedEvent) {
+        dataPlatformApiClient.sendReservation()
+    }
+}

--- a/src/main/kotlin/hhplus/concertreservation/infrastructure/event/reservation/ReservationSpringEventPublisher.kt
+++ b/src/main/kotlin/hhplus/concertreservation/infrastructure/event/reservation/ReservationSpringEventPublisher.kt
@@ -1,0 +1,16 @@
+package hhplus.concertreservation.infrastructure.event.reservation
+
+import hhplus.concertreservation.domain.concert.event.ReservationCreatedEvent
+import hhplus.concertreservation.infrastructure.event.EventPublisher
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+class ReservationSpringEventPublisher(
+    private val applicationEventPublisher: ApplicationEventPublisher
+) : EventPublisher<ReservationCreatedEvent> {
+
+    override fun publish(event: ReservationCreatedEvent) {
+        applicationEventPublisher.publishEvent(event)
+    }
+}


### PR DESCRIPTION
## 작업 내역

1. 시나리오 내 트랜잭션 범위 고려와 이벤트 기반 트랜잭션 분리 로직 설계 문서 작성 ([링크](https://eastshine12.tistory.com/71))
2. 좌석 예약 정보를 외부 데이터 플랫폼에 이벤트 처리하는 로직 작성

<br/>

## 의사결정 흐름

### 1. 트랜잭션 고려 및 분리
  - 현재 시나리오의 트랜잭션 로직을 분석한 결과, `결제 처리` 로직에 긴 트랜잭션 범위로 인해 문제가 발생하고 있음을 확인했습니다. 파사드 계층에서 트랜잭션을 묶어 하나의 서비스 호출이 실패하면 전체가 롤백되는 구조로, 트랜잭션의 길이로 인해 DB 커넥션 점유 시간이 증가하는 문제가 있었습니다.
  - 이러한 문제를 해결하기 위해 이벤트 기반 설계를 도입을 검토했습니다. 핵심 로직은 기존 방식대로 유지하면서 부가 로직은 이벤트 구독 방식으로 트랜잭션을 분리해 트랜잭션 길이를 줄이고 효율성을 높이는 방향으로 설계했습니다.

### 2. 예약 생성 로직에 이벤트 처리 추가
  - 멘토링에서 받은 조언을 바탕으로, 예약 생성 로직에서 이벤트를 발급하여 외부 데이터 플랫폼이 이를 구독하고 처리하도록 구현했습니다. 기본 로직은 트랜잭션 내에서 유지하면서 외부 API 호출 로직은 비동기 이벤트를 통해 처리하여 트랜잭션을 분리했습니다.

<br/>

## 리뷰 포인트

### 1. 외부 플랫폼 클래스의 패키지 구조
  - 멘토링에서 이벤트 리스너의 패키지 구조에 대한 조언을 받았습니다. 현재 `DataPlatformApiClient`와 같은 외부 플랫폼 클래스는 인프라스트럭처 레이어에 작성했으며, 이벤트를 구독하는 `ExternalPlatformEventListener`도 해당 도메인이 외부에 존재하기 때문에 동일한 인프라스트럭처 레이어에 위치시켰습니다.
  - 이벤트 리스너가 프레젠테이션이나 도메인 레이어에 위치해야 할까 고민이 되었는데 인프라스트럭처 레이어에서 구독 로직을 다루는 것이 적절한지 궁금합니다.






 