### PR TITLE
[Step 17] kafka 컨테이너를 생성하는 docker compose 작성과 Testcontainer를 사용한 kafka 연동 테스트 수행

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
+    implementation("org.springframework.kafka:spring-kafka")
     compileOnly("org.projectlombok:lombok")
     runtimeOnly("com.h2database:h2")
     annotationProcessor("org.projectlombok:lombok")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("io.mockk:mockk:1.13.12")
     testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("org.testcontainers:kafka")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  kafka:
+    image: bitnami/kafka:latest
+    ports:
+      - '9092:9092'
+      - '9094:9094'
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_CFG_LOG_DIRS=/tmp/kraft-combined-logs
+    networks:
+      - kafka-network
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    ports:
+      - "8082:8080"
+    environment:
+      DYNAMIC_CONFIG_ENABLED: 'true'
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      - kafka
+    networks:
+      - kafka-network
+
+networks:
+  kafka-network:
+    driver: bridge

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,15 @@ spring:
     redis:
       host: localhost
       port: 6379
+  kafka:
+    bootstrap-servers: localhost:9094
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
 logging:
   level:

--- a/src/test/kotlin/hhplus/concertreservation/kafka/KafkaIntegrationTest.kt
+++ b/src/test/kotlin/hhplus/concertreservation/kafka/KafkaIntegrationTest.kt
@@ -1,14 +1,19 @@
 package hhplus.concertreservation.kafka
 
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.consumer.ConsumerRecords
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.kafka.common.serialization.StringSerializer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -16,16 +21,38 @@ import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 import java.util.*
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
 import kotlin.test.assertTrue
 
 @SpringBootTest
 class KafkaIntegrationTest {
     private lateinit var kafkaContainer: KafkaContainer
+    private lateinit var producerProps: Properties
+    private lateinit var consumerProps: Properties
 
     @BeforeEach
     fun setUp() {
         kafkaContainer = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
         kafkaContainer.start()
+
+        // Kafka Producer 설정
+        producerProps =
+            Properties().apply {
+                put("bootstrap.servers", kafkaContainer.bootstrapServers)
+                put("key.serializer", StringSerializer::class.java.canonicalName)
+                put("value.serializer", StringSerializer::class.java.canonicalName)
+            }
+
+        // Kafka Consumer 설정
+        consumerProps =
+            Properties().apply {
+                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.bootstrapServers)
+                put(ConsumerConfig.GROUP_ID_CONFIG, "test-group")
+                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.canonicalName)
+                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.canonicalName)
+                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            }
     }
 
     @AfterEach
@@ -36,27 +63,10 @@ class KafkaIntegrationTest {
     @Test
     fun `test Kafka producer and consumer with Testcontainers`() {
         // given
-
-        // Kafka Producer 설정
-        val producerProps =
-            Properties().apply {
-                put("bootstrap.servers", kafkaContainer.bootstrapServers)
-                put("key.serializer", StringSerializer::class.java.canonicalName)
-                put("value.serializer", StringSerializer::class.java.canonicalName)
-            }
         val producer = KafkaProducer<String, String>(producerProps)
         producer.send(ProducerRecord("test-topic", "Hello, Kafka!"))
         producer.close()
 
-        // Kafka Consumer 설정
-        val consumerProps =
-            Properties().apply {
-                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.bootstrapServers)
-                put(ConsumerConfig.GROUP_ID_CONFIG, "test-group")
-                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.canonicalName)
-                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.canonicalName)
-                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-            }
         val consumer = KafkaConsumer<String, String>(consumerProps)
         consumer.subscribe(listOf("test-topic"))
 
@@ -67,5 +77,106 @@ class KafkaIntegrationTest {
         // then
         assertTrue(records.count() > 0, "No messages consumed")
         assertEquals("Hello, Kafka!", records.iterator().next().value())
+    }
+
+    @Test
+    fun `must consume 100 messages produced concurrently`() {
+        // given
+        val producer = KafkaProducer<String, String>(producerProps)
+        val messages = (1..100).map { "Message$it" }
+        val executor = Executors.newFixedThreadPool(10)
+
+        val tasks =
+            messages.map { message ->
+                Callable {
+                    producer.send(ProducerRecord("test-topic2", message))
+                }
+            }
+
+        executor.invokeAll(tasks)
+        executor.shutdown()
+        producer.close()
+
+        val consumer = KafkaConsumer<String, String>(consumerProps)
+        consumer.subscribe(listOf("test-topic2"))
+
+        // when
+        val records: ConsumerRecords<String, String> = consumer.poll(Duration.ofSeconds(10))
+        consumer.close()
+
+        // then
+        val consumedMessages = records.map { it.value() }.toSet()
+        assertEquals(100, consumedMessages.size)
+        assertTrue(messages.all { it in consumedMessages })
+    }
+
+    @Test
+    fun `must ensure messages with the same key are in the same partition`() {
+        // given
+        val topic = "test-topic-three-partitions"
+        val messages =
+            listOf(
+                "Key1" to "Message1",
+                "Key2" to "Message2",
+                "Key3" to "Message3",
+                "Key1" to "Message4",
+                "Key2" to "Message5",
+                "Key3" to "Message6",
+            )
+
+        // create topic
+        val adminProps =
+            Properties().apply {
+                put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.bootstrapServers)
+            }
+        val adminClient = AdminClient.create(adminProps)
+        val newTopic = NewTopic(topic, 3, 1.toShort())
+        adminClient.createTopics(listOf(newTopic)).all().get()
+        adminClient.close()
+
+        // produce
+        val producer = KafkaProducer<String, String>(producerProps)
+        messages.forEach { (key, message) ->
+            producer.send(ProducerRecord(topic, key, message))
+        }
+        producer.close()
+
+        // consume
+        val consumer = KafkaConsumer<String, String>(consumerProps)
+        consumer.assign(
+            listOf(
+                TopicPartition(topic, 0),
+                TopicPartition(topic, 1),
+                TopicPartition(topic, 2),
+            )
+        )
+        val partitionMessages = mutableMapOf<Int, MutableList<Pair<String, String>>>()
+        consumer.seekToBeginning(consumer.assignment())
+        val records = consumer.poll(Duration.ofSeconds(10))
+        records.forEach { record ->
+            partitionMessages.computeIfAbsent(record.partition()) { mutableListOf() }
+                .add(record.key() to record.value())
+        }
+        consumer.close()
+
+        // then
+        partitionMessages.forEach { (partition, messages) ->
+            println("Partition $partition: $messages")
+        }
+
+        messages.forEach { (key, message) ->
+            val partition = partitionMessages.entries.find { it.value.contains(key to message) }?.key
+            assertNotNull(partition)
+        }
+
+        val partitionNumForMessage1 = partitionMessages.entries.find { it.value.contains("Key1" to "Message1") }?.key
+        val partitionNumForMessage2 = partitionMessages.entries.find { it.value.contains("Key2" to "Message2") }?.key
+        val partitionNumForMessage3 = partitionMessages.entries.find { it.value.contains("Key3" to "Message3") }?.key
+        val partitionNumForMessage4 = partitionMessages.entries.find { it.value.contains("Key1" to "Message4") }?.key
+        val partitionNumForMessage5 = partitionMessages.entries.find { it.value.contains("Key2" to "Message5") }?.key
+        val partitionNumForMessage6 = partitionMessages.entries.find { it.value.contains("Key3" to "Message6") }?.key
+        assertEquals(partitionNumForMessage1, partitionNumForMessage4)
+        assertEquals(partitionNumForMessage2, partitionNumForMessage5)
+        assertEquals(partitionNumForMessage3, partitionNumForMessage6)
     }
 }

--- a/src/test/kotlin/hhplus/concertreservation/kafka/KafkaIntegrationTest.kt
+++ b/src/test/kotlin/hhplus/concertreservation/kafka/KafkaIntegrationTest.kt
@@ -1,0 +1,71 @@
+package hhplus.concertreservation.kafka
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.containers.KafkaContainer
+import org.testcontainers.utility.DockerImageName
+import java.time.Duration
+import java.util.*
+import kotlin.test.assertTrue
+
+@SpringBootTest
+class KafkaIntegrationTest {
+    private lateinit var kafkaContainer: KafkaContainer
+
+    @BeforeEach
+    fun setUp() {
+        kafkaContainer = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"))
+        kafkaContainer.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        kafkaContainer.stop()
+    }
+
+    @Test
+    fun `test Kafka producer and consumer with Testcontainers`() {
+        // given
+
+        // Kafka Producer 설정
+        val producerProps =
+            Properties().apply {
+                put("bootstrap.servers", kafkaContainer.bootstrapServers)
+                put("key.serializer", StringSerializer::class.java.canonicalName)
+                put("value.serializer", StringSerializer::class.java.canonicalName)
+            }
+        val producer = KafkaProducer<String, String>(producerProps)
+        producer.send(ProducerRecord("test-topic", "Hello, Kafka!"))
+        producer.close()
+
+        // Kafka Consumer 설정
+        val consumerProps =
+            Properties().apply {
+                put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.bootstrapServers)
+                put(ConsumerConfig.GROUP_ID_CONFIG, "test-group")
+                put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.canonicalName)
+                put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer::class.java.canonicalName)
+                put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+            }
+        val consumer = KafkaConsumer<String, String>(consumerProps)
+        consumer.subscribe(listOf("test-topic"))
+
+        // when
+        val records: ConsumerRecords<String, String> = consumer.poll(Duration.ofSeconds(5))
+        consumer.close()
+
+        // then
+        assertTrue(records.count() > 0, "No messages consumed")
+        assertEquals("Hello, Kafka!", records.iterator().next().value())
+    }
+}


### PR DESCRIPTION
## 작업 내역

1. docker-compose.yml 을 작성하여 docker compose로 kafka, kafka-ui 컨테이너 생성
2. testcontainer를 사용하여 kafka producer, consumer 연동 테스트 수행

<br/>

## 의사결정 흐름

### 1. Kafka 설치 및 모니터링을 위한 Docker Compose 작성
  - 도커 컨테이너로 Kafka와 Kafka-UI를 실행하기 위해 docker-compose.yml을 작성했습니다.
  - Kafka-UI 연동: 모니터링 편의를 위해 Kafka-UI를 추가하고, 애플리케이션과의 통신을 위해 도커 네트워크를 설정하였습니다.
  - External Listener 설정: 로컬 환경의 Spring Boot 애플리케이션이 컨테이너와 통신할 수 있도록 외부 포트(9094)를 리스너로 설정하였습니다.
  - KRaft 모드 활성화:
    - ZooKeeper 없이 Kafka 자체적으로 메타데이터를 관리하는 KRaft(Kafka Raft)를 사용하였습니다.
    - `KAFKA_CFG_NODE_ID`를 활용하여 노드 ID를 설정하고, `KAFKA_CFG_PROCESS_ROLES`로 Controller와 Broker 역할을 분리하며 KRaft 모드를 활성화하였습니다.
    - KRaft에 맞는 별도의 포트를 설정하여 각 역할에 접근할 수 있도록 구성했습니다.
### 2. Spring Boot 설정
  - 컨슈머 그룹 내 컨슈머 리밸런싱이 일어날 때 메시지 데이터의 유실 방지를 위해 `auto.offset.reset`을 earliest로 설정.
  - Kafka 메시지의 key와 value에 대해 직렬화 및 역직렬화 설정 추가.
### 3.	Testcontainers를 활용한 Kafka 연동 테스트
  - 테스트 환경에서 독립적으로 Kafka를 실행하기 위해 Testcontainers를 설정하였습니다.
  - 다음과 같은 시나리오로 테스트를 수행했습니다:
    1.	기본 메시지 발행 및 소비 확인: 프로듀서가 메시지를 발행했을 때 컨슈머가 이를 정상적으로 소비하는지 검증.
    2. 동시 발행 처리: 100개의 메시지를 동시에 발행했을 때, 메시지가 유실 없이 컨슈머에게 도달하는지 확인.
    3.	파티션 분배 확인: 파티션이 3개인 토픽에서 동일한 키를 가진 메시지가 같은 파티션에 적절히 분배되는지 검증.

<br/>




 