### PR TITLE
[Step 19] 부하 테스트 대상을 선정하고, 컨테이너 리소스 & 시나리오 별로 성능 측정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+# Base image
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+ADD build/libs/concert-reservation-0.0.1-SNAPSHOT.jar app.jar
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - [Redis 기반의 캐싱 및 대기열 관리를 통한 콘서트 예약 서비스 성능 개선](https://eastshine12.tistory.com/69)
 - [서비스 확장을 위한 트랜잭션 분리와 이벤트 기반 설계](https://eastshine12.tistory.com/71)
 - [콘서트 예약 서비스의 인덱스 설계와 성능 비교](https://eastshine12.tistory.com/70)
+- [부하 테스트: 유저 행동 기반 시나리오로 시스템 한계 측정과 SLA, SLO 검증](https://eastshine12.tistory.com/72)
 
 <br/>
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,10 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
     implementation("org.springframework.kafka:spring-kafka")
+    implementation("mysql:mysql-connector-java:8.0.33")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-prometheus")
     compileOnly("org.projectlombok:lombok")
-    runtimeOnly("com.h2database:h2")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
@@ -52,6 +54,7 @@ dependencies {
     testImplementation("org.testcontainers:junit-jupiter:1.19.3")
     testImplementation("org.testcontainers:kafka")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly("com.h2database:h2")
 }
 
 kotlin {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,25 @@
 services:
+  spring-boot-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - SPRING_PROFILES_ACTIVE=container
+    ports:
+      - "8080:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "2G"
+    depends_on:
+      - mysql
+      - redis
+    networks:
+      - kafka-network
+      - k6
+      - grafana
+
   kafka:
     image: bitnami/kafka:latest
     ports:
@@ -12,7 +33,7 @@ services:
       - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@localhost:9093
       - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
       - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
-      - KAFKA_CFG_LOG_DIRS=/tmp/kraft-combined-logs
+      # - KAFKA_CFG_LOG_DIRS=/tmp/kraft-combined-logs
     networks:
       - kafka-network
 
@@ -29,6 +50,83 @@ services:
     networks:
       - kafka-network
 
+  influxdb:
+    image: influxdb:1.8
+    networks:
+      - k6
+      - grafana
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - grafana
+
+  grafana:
+    image: grafana/grafana:latest
+    networks:
+      - grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_SERVER_SERVE_FROM_SUB_PATH=true
+    volumes:
+      - ./docker/grafana/dashboards:/var/lib/grafana/dashboards
+      - ./docker/grafana/grafana-dashboard.yaml:/etc/grafana/provisioning/dashboards/dashboard.yaml
+      - ./docker/grafana/grafana-datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
+
+  k6:
+    image: loadimpact/k6:latest
+    networks:
+      - k6
+    ports:
+      - "6565:6565"
+    environment:
+      - K6_OUT=influxdb=http://influxdb:8086/k6
+    volumes:
+      - ./docker/k6/scripts:/scripts
+    command: run /scripts/full_scenario_test.js
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=concert
+      - MYSQL_USER=hhplus
+      - MYSQL_PASSWORD=1234
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - kafka-network
+      - k6
+      - grafana
+
+  redis:
+    image: redis:7.0
+    ports:
+      - "6379:6379"
+    command: [ "redis-server", "--appendonly", "yes" ]
+    networks:
+      - kafka-network
+      - k6
+      - grafana
+
+volumes:
+  mysql-data:
 networks:
+  k6:
+  grafana:
   kafka-network:
     driver: bridge

--- a/docker/grafana/dashboards/k6-load-testing-results_rev3.json
+++ b/docker/grafana/dashboards/k6-load-testing-results_rev3.json
@@ -1,0 +1,1618 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_K6",
+      "label": "k6",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "influxdb",
+      "pluginName": "InfluxDB"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "4.4.1"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "influxdb",
+      "name": "InfluxDB",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "description": "A dashboard for visualizing results from the k6.io load testing tool, using the InfluxDB exporter",
+  "editable": true,
+  "gnetId": 2587,
+  "graphTooltip": 2,
+  "hideControls": false,
+  "id": null,
+  "uid": "k6",
+  "links": [],
+  "refresh": "5s",
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "k6influxdb",
+          "fill": 1,
+          "id": 1,
+          "interval": ">1s",
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": true,
+            "min": true,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Active VUs",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "vus",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Virtual Users",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "k6influxdb",
+          "fill": 1,
+          "id": 17,
+          "interval": "1s",
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Requests per Second",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "http_reqs",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "sum"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Requests per Second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "k6influxdb",
+          "fill": 1,
+          "id": 7,
+          "interval": "1s",
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Num Errors",
+              "color": "#BF1B00"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "Num Errors",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "errors",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "count"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Errors Per Second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "k6influxdb",
+          "fill": 1,
+          "id": 10,
+          "interval": ">1s",
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "Num Errors",
+              "color": "#BF1B00"
+            }
+          ],
+          "spaceLength": 10,
+          "span": 3,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "$tag_check",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "check"
+                  ],
+                  "type": "tag"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "checks",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "sum"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Checks Per Second",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "k6influxdb",
+          "decimals": 2,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 11,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT mean(\"value\") FROM $Measurement WHERE $timeFilter ",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": "",
+          "title": "$Measurement (mean)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "k6influxdb",
+          "decimals": 2,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 14,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT max(\"value\") FROM $Measurement WHERE $timeFilter",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": "",
+          "title": "$Measurement (max)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "k6influxdb",
+          "decimals": 2,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 15,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT median(\"value\") FROM $Measurement WHERE $timeFilter",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": "",
+          "title": "$Measurement (med)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "k6influxdb",
+          "decimals": 2,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 16,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT min(\"value\") FROM $Measurement WHERE $timeFilter and value > 0",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": "",
+          "title": "$Measurement (min)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "current"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "k6influxdb",
+          "decimals": 2,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 12,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT percentile(\"value\", 90) FROM $Measurement WHERE $timeFilter",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": "",
+          "title": "$Measurement (p90)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": false,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "datasource": "k6influxdb",
+          "decimals": 2,
+          "format": "ms",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
+          "height": "50px",
+          "id": 13,
+          "interval": null,
+          "links": [],
+          "mappingType": 1,
+          "mappingTypes": [
+            {
+              "name": "value to text",
+              "value": 1
+            },
+            {
+              "name": "range to text",
+              "value": 2
+            }
+          ],
+          "maxDataPoints": 100,
+          "nullPointMode": "connected",
+          "nullText": null,
+          "postfix": "",
+          "postfixFontSize": "50%",
+          "prefix": "",
+          "prefixFontSize": "50%",
+          "rangeMaps": [
+            {
+              "from": "null",
+              "text": "N/A",
+              "to": "null"
+            }
+          ],
+          "span": 2,
+          "sparkline": {
+            "fillColor": "rgba(31, 118, 189, 0.18)",
+            "full": false,
+            "lineColor": "rgb(31, 120, 193)",
+            "show": false
+          },
+          "tableColumn": "",
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT percentile(\"value\", 95) FROM $Measurement WHERE $timeFilter ",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": "",
+          "title": "$Measurement (p95)",
+          "type": "singlestat",
+          "valueFontSize": "80%",
+          "valueMaps": [
+            {
+              "op": "=",
+              "text": "N/A",
+              "value": "null"
+            }
+          ],
+          "valueName": "avg"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "k6influxdb",
+          "description": "Grouped by 1 sec intervals",
+          "fill": 1,
+          "height": "250px",
+          "id": 5,
+          "interval": ">1s",
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "max",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "/^$Measurement$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT max(\"value\") FROM /^$Measurement$/ WHERE $timeFilter and value > 0 GROUP BY time($__interval) fill(none)",
+              "rawQuery": true,
+              "refId": "C",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "max"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "p95",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "/^$Measurement$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT percentile(\"value\", 95) FROM /^$Measurement$/ WHERE $timeFilter and value > 0 GROUP BY time($__interval) fill(none)",
+              "rawQuery": true,
+              "refId": "D",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      95
+                    ],
+                    "type": "percentile"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "p90",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "/^$Measurement$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT percentile(\"value\", 90) FROM /^$Measurement$/ WHERE $timeFilter and value > 0 GROUP BY time($__interval) fill(none)",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [
+                      "90"
+                    ],
+                    "type": "percentile"
+                  }
+                ]
+              ],
+              "tags": []
+            },
+            {
+              "alias": "min",
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "none"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "/^$Measurement$/",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT min(\"value\") FROM /^$Measurement$/ WHERE $timeFilter and value > 0 GROUP BY time($__interval) fill(none)",
+              "rawQuery": true,
+              "refId": "E",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "min"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "$Measurement (over time)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "label": null,
+              "logBase": 2,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ]
+        },
+        {
+          "cards": {
+            "cardPadding": null,
+            "cardRound": null
+          },
+          "color": {
+            "cardColor": "rgb(0, 234, 255)",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateRdYlGn",
+            "exponent": 0.5,
+            "mode": "spectrum"
+          },
+          "dataFormat": "timeseries",
+          "datasource": "k6influxdb",
+          "heatmap": {},
+          "height": "250px",
+          "highlightCards": true,
+          "id": 8,
+          "interval": ">1s",
+          "links": [],
+          "span": 6,
+          "targets": [
+            {
+              "dsType": "influxdb",
+              "groupBy": [
+                {
+                  "params": [
+                    "$__interval"
+                  ],
+                  "type": "time"
+                },
+                {
+                  "params": [
+                    "null"
+                  ],
+                  "type": "fill"
+                }
+              ],
+              "measurement": "http_req_duration",
+              "orderByTime": "ASC",
+              "policy": "default",
+              "query": "SELECT \"value\" FROM $Measurement WHERE $timeFilter and value > 0",
+              "rawQuery": true,
+              "refId": "A",
+              "resultFormat": "time_series",
+              "select": [
+                [
+                  {
+                    "params": [
+                      "value"
+                    ],
+                    "type": "field"
+                  },
+                  {
+                    "params": [],
+                    "type": "mean"
+                  }
+                ]
+              ],
+              "tags": []
+            }
+          ],
+          "title": "$Measurement (over time)",
+          "tooltip": {
+            "show": true,
+            "showHistogram": true
+          },
+          "tooltipDecimals": null,
+          "type": "heatmap",
+          "xAxis": {
+            "show": true
+          },
+          "xBucketNumber": null,
+          "xBucketSize": null,
+          "yAxis": {
+            "decimals": null,
+            "format": "ms",
+            "logBase": 2,
+            "max": null,
+            "min": null,
+            "show": true,
+            "splitFactor": null
+          },
+          "yBucketNumber": null,
+          "yBucketSize": null
+        }
+      ],
+      "repeat": "Measurement",
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "$Measurement",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": 250,
+      "panels": [],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": false,
+      "title": "Dashboard Row",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "tags": [],
+          "text": "http_req_duration + http_req_blocked",
+          "value": [
+            "http_req_duration",
+            "http_req_blocked"
+          ]
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "Measurement",
+        "options": [
+          {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": true,
+            "text": "http_req_duration",
+            "value": "http_req_duration"
+          },
+          {
+            "selected": true,
+            "text": "http_req_blocked",
+            "value": "http_req_blocked"
+          },
+          {
+            "selected": false,
+            "text": "http_req_connecting",
+            "value": "http_req_connecting"
+          },
+          {
+            "selected": false,
+            "text": "http_req_looking_up",
+            "value": "http_req_looking_up"
+          },
+          {
+            "selected": false,
+            "text": "http_req_receiving",
+            "value": "http_req_receiving"
+          },
+          {
+            "selected": false,
+            "text": "http_req_sending",
+            "value": "http_req_sending"
+          },
+          {
+            "selected": false,
+            "text": "http_req_waiting",
+            "value": "http_req_waiting"
+          }
+        ],
+        "query": "http_req_duration,http_req_blocked,http_req_connecting,http_req_looking_up,http_req_receiving,http_req_sending,http_req_waiting",
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "k6 Load Testing Results",
+  "version": 22
+}

--- a/docker/grafana/grafana-dashboard.yaml
+++ b/docker/grafana/grafana-dashboard.yaml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'default'       
+    org_id: 1             
+    folder: ''            
+    type: 'file'          
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/grafana/grafana-datasource.yaml
+++ b/docker/grafana/grafana-datasource.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: k6influxdb
+    type: influxdb
+    access: proxy
+    database: k6
+    url: http://influxdb:8086
+    isDefault: true

--- a/docker/k6/scripts/active_scenario.js
+++ b/docker/k6/scripts/active_scenario.js
@@ -1,0 +1,106 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import exec from 'k6/execution';
+
+const CONFIG = {
+    baseUrl: 'http://spring-boot-app:8080',
+    concertId: 1,
+    scheduleId: 1,
+};
+
+export let options = {
+  stages: [
+    { duration: '10s', target: 10 },  // 10초 동안 10 VU로 증가
+    { duration: '10s', target: 15 },  // 10초 동안 20 VU로 증가
+    { duration: '10s', target: 20 },  // 10초 동안 30 VU로 증가
+    { duration: '10s', target: 25 }, // 10초 동안 50 VU로 증가
+    { duration: '10s', target: 30 }, // 10초 동안 50 VU로 증가
+    { duration: '10s', target: 0 },   // 10초 동안 0으로 감소
+  ],
+  thresholds: {
+      http_req_duration: ['p(99)<400'], // p99가 400ms 이하
+      http_req_failed: ['rate<0.01'],   // 실패율이 1% 이하
+  },
+};
+
+export default function () {
+    let currentId = exec.scenario.iterationInTest + 1;
+    let token = getWaitingToken(currentId);
+
+    getConcertSeats(token);
+    sleep(2);
+    let reservationId = reserveSeat(token, currentId);
+    sleep(2);
+    processPayment(token, reservationId, currentId);
+    sleep(2);
+}
+
+export function teardown(data) {
+    console.log('테스트 완료');
+}
+
+function getWaitingToken(currentId) {
+    let headers = {
+        'Content-Type': 'application/json',
+    };
+    let payload = JSON.stringify({
+        userId: currentId,
+        concertId: CONFIG.concertId,
+        concertScheduleId: CONFIG.scheduleId,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/waiting-queues`, payload, { headers });
+    check(res, { 'status is 201': (r) => r.status === 201 });
+
+    return JSON.parse(res.body).token;
+}
+
+function getConcertSchedules(token) {
+    let headers = {
+      'Content-Type': 'application/json',
+      'Queue-Token': token,
+    };
+    let res = http.get(`${CONFIG.baseUrl}/api/concerts/${CONFIG.concertId}`, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}
+
+function getConcertSeats(token) {
+    let headers = {
+      'Content-Type': 'application/json',
+      'Queue-Token': token,
+    };
+    let res = http.get(
+        `${CONFIG.baseUrl}/api/concerts/${CONFIG.concertId}/schedules/${CONFIG.scheduleId}/seats`,
+        { headers }
+    );
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}
+
+function reserveSeat(token, currentId) {
+    let headers = {
+      'Content-Type': 'application/json',
+      'Queue-Token': token,
+    };
+    let payload = JSON.stringify({
+        userId: currentId,
+        concertId: 1,
+        scheduleId: 1,
+        seatId: currentId,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/concerts/reservations`, payload, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+
+    return JSON.parse(res.body).reservationId;
+}
+
+function processPayment(token, reservationId, currentId) {
+    let headers = {
+      'Content-Type': 'application/json',
+      'Queue-Token': token,
+    };
+    let payload = JSON.stringify({
+        userId: currentId,
+        reservationId: reservationId,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/payments`, payload, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/docker/k6/scripts/full_scenario_test.js
+++ b/docker/k6/scripts/full_scenario_test.js
@@ -1,0 +1,92 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+import exec from 'k6/execution';
+
+const CONFIG = {
+    baseUrl: 'http://spring-boot-app:8080',
+    concertId: 1,
+    scheduleId: 1,
+    userId: 1,
+};
+
+export let options = {
+    vus: 100, // 동시 가상 유저 수
+    duration: '1m', // 테스트 시간
+    thresholds: { http_req_duration: ['p(95)<300'] }, // 95% 요청이 300ms 이하
+};
+
+export default function () {
+    let token = getWaitingToken();
+
+    let headers = {
+        'Content-Type': 'application/json',
+        'Queue-Token': token,
+    };
+    
+    getQueueStatus(headers);
+    getConcertSchedules(headers);
+    getConcertSeats(headers);
+    let reservationId = reserveSeat(headers);
+    processPayment(headers, reservationId);
+
+    sleep(1);
+}
+
+export function teardown(data) {
+    console.log('테스트 완료');
+}
+
+function getWaitingToken() {
+    let headers = {
+        'Content-Type': 'application/json',
+    };
+    let payload = JSON.stringify({
+        userId: CONFIG.userId,
+        concertId: CONFIG.concertId,
+        concertScheduleId: CONFIG.scheduleId,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/waiting-queues`, payload, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+
+    return JSON.parse(res.body).token;
+}
+
+function getQueueStatus(headers) {
+    let res = http.get(`${CONFIG.baseUrl}/api/waiting-queues`, { headers }, );
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}
+
+function getConcertSchedules(headers) {
+    let res = http.get(`${CONFIG.baseUrl}/api/concerts/${CONFIG.concertId}`, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}
+
+function getConcertSeats(headers) {
+    let res = http.get(
+        `${CONFIG.baseUrl}/api/concerts/${CONFIG.concertId}/schedules/${CONFIG.scheduleId}/seats`,
+        { headers }
+    );
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}
+
+function reserveSeat(headers) {
+    let payload = JSON.stringify({
+        userId: 1,
+        concertId: 1,
+        scheduleId: 1,
+        seatId: exec.scenario.iterationInTest + 292855,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/concerts/reservations`, payload, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+
+    return JSON.parse(res.body).reservationId;
+}
+
+function processPayment(headers, reservationId) {
+    let payload = JSON.stringify({
+        userId: 1,
+        reservationId: reservationId,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/payments`, payload, { headers });
+    check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/docker/k6/scripts/waiting_scenario.js
+++ b/docker/k6/scripts/waiting_scenario.js
@@ -1,0 +1,70 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend } from 'k6/metrics';
+import exec from 'k6/execution';
+
+const waitingTokenDuration = new Trend('waiting_token_duration_p99');
+const queueStatusDuration = new Trend('queue_status_duration_p99');
+
+const CONFIG = {
+    baseUrl: 'http://spring-boot-app:8080',
+    concertId: 1,
+    scheduleId: 1,
+};
+
+export let options = {
+    // stages: [
+    //   { duration: '10s', target: 10 },  // 10초 동안 10 VU로 증가
+    //   { duration: '10s', target: 30 },  // 10초 동안 30 VU로 증가
+    //   { duration: '10s', target: 50 },  // 10초 동안 50 VU로 증가
+    //   { duration: '10s', target: 100 }, // 10초 동안 100 VU로 증가
+    //   { duration: '10s', target: 200 }, // 10초 동안 200 VU로 증가
+    //   { duration: '10s', target: 0 },   // 10초 동안 0으로 감소
+    // ],
+    stages: [
+        { duration: '10s', target: 100 },  // 10초 동안 100 VU
+        { duration: '10s', target: 1000 }, // 10초 동안 1000 VU로 급증
+        { duration: '30s', target: 100 },  // 30초 동안 100 VU로 감소
+    ],
+    thresholds: {
+        http_req_duration: ['p(99)<400'], // p99가 400ms 이하
+        http_req_failed: ['rate<0.01'],   // 실패율이 1% 이하
+    },
+};
+
+export default function () {
+    // 토큰 발급
+    let token = getWaitingToken()
+
+    // 토큰 상태 조회
+    for (let i = 0; i < 5; i++) { // 5회 반복
+        getQueueStatus(token)
+        sleep(1);
+    }
+}
+
+function getWaitingToken() {
+    let headers = {
+        'Content-Type': 'application/json',
+    };
+    let payload = JSON.stringify({
+        userId: exec.scenario.iterationInTest + 1,
+        concertId: CONFIG.concertId,
+        concertScheduleId: CONFIG.scheduleId,
+    });
+    let res = http.post(`${CONFIG.baseUrl}/api/waiting-queues`, payload, { headers });
+    check(res, { 'status is 201': (r) => r.status === 201 });
+    waitingTokenDuration.add(res.timings.duration);
+
+    return JSON.parse(res.body).token;
+}
+
+function getQueueStatus(token) {
+    let headers = {
+        'Content-Type': 'application/json',
+        'Queue-Token': token,
+    };
+    let res = http.get(`${CONFIG.baseUrl}/api/waiting-queues`, { headers }, );
+    check(res, { 'status is 200': (r) => r.status === 200 });
+    queueStatusDuration.add(res.timings.duration);
+}

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'spring-boot-app'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['spring-boot-app:8080']

--- a/src/main/kotlin/hhplus/concertreservation/config/RedisConfig.kt
+++ b/src/main/kotlin/hhplus/concertreservation/config/RedisConfig.kt
@@ -40,13 +40,14 @@ class RedisConfig(
 
     @Bean
     fun cacheManager(redisConnectionFactory: RedisConnectionFactory): RedisCacheManager {
-        val objectMapper = ObjectMapper().apply {
-            registerModule(JavaTimeModule())
-            activateDefaultTyping(
-                polymorphicTypeValidator,
-                ObjectMapper.DefaultTyping.NON_FINAL,
-            )
-        }
+        val objectMapper =
+            ObjectMapper().apply {
+                registerModule(JavaTimeModule())
+                activateDefaultTyping(
+                    polymorphicTypeValidator,
+                    ObjectMapper.DefaultTyping.NON_FINAL,
+                )
+            }
         val jsonSerializer = GenericJackson2JsonRedisSerializer(objectMapper)
         val config =
             RedisCacheConfiguration.defaultCacheConfig()

--- a/src/main/kotlin/hhplus/concertreservation/config/WebConfig.kt
+++ b/src/main/kotlin/hhplus/concertreservation/config/WebConfig.kt
@@ -12,6 +12,6 @@ class WebConfig(
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry.addInterceptor(waitingQueueTokenInterceptor)
             .addPathPatterns("/**")
-            .excludePathPatterns("/api/waiting-queues")
+            .excludePathPatterns("/api/waiting-queues", "/actuator", "/actuator/**", "/metrics")
     }
 }

--- a/src/main/kotlin/hhplus/concertreservation/domain/waitingQueue/component/QueueManager.kt
+++ b/src/main/kotlin/hhplus/concertreservation/domain/waitingQueue/component/QueueManager.kt
@@ -27,6 +27,12 @@ class QueueManager(
                     expiresAt = null,
                 ),
             )
+        // 부하 테스트를 위한 임시 코드 (토큰 활성화)
+        waitingQueueRepository.moveToActiveQueue(
+            scheduleId = scheduleId,
+            tokens = setOf(token),
+            expiresInMinutes = 10L,
+        )
         return waitingQueue
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,24 +1,55 @@
 spring:
+  profiles:
+    active: local
   application:
     name: concert-reservation
-  h2:
-    console:
-      enabled: true
-  datasource:
-    url: jdbc:h2:mem:concert
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
   jpa:
     hibernate:
-      ddl-auto: create
-    show_sql: true
+      ddl-auto: validate
+    show_sql: off
     properties:
       hibernate:
         format_sql: true
         use_sql_comments: true
         globally_quoted_identifiers: true
         globally_quoted_identifiers_skip_column_definitions: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,metrics
+  endpoint:
+    prometheus:
+      enabled: true
+
+reservation:
+  expireMinutes: 5 # 임시배정 유효 시간(분)
+  expireCheckRate: 60000 # 만료 체크 주기(ms)
+  syncAvailableSeatsRate: 60000 # 예약 가능 좌석 수 동기화 주기(ms)
+
+waiting-queue:
+  activateRate: 60000 # 대기열 활성화 체크 주기(ms)
+  expireCheckRate: 60000 # 만료 체크 주기(ms)
+  activeUsers: 100 # 활성화할 최대 유저 수
+  expireMinutes: 5 # 대기열 유효 시간(분)
+
+outbox:
+  scheduler:
+    fixedRate: 60000 # 체크 주기(ms)
+    timeLimitMinutes: 10 # 체크 시간 범위(분)
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mysql://localhost:3307/concert
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: hhplus
+    password: 1234
   data:
     redis:
       host: localhost
@@ -41,18 +72,35 @@ logging:
       hibernate.type:
         descriptor.sql.BasicBinder: trace
 
-reservation:
-  expireMinutes: 5 # 임시배정 유효 시간(분)
-  expireCheckRate: 60000 # 만료 체크 주기(ms)
-  syncAvailableSeatsRate: 60000 # 예약 가능 좌석 수 동기화 주기(ms)
+---
 
-waiting-queue:
-  activateRate: 6000 # 대기열 활성화 체크 주기(ms)
-  expireCheckRate: 6000 # 만료 체크 주기(ms)
-  activeUsers: 2 # 활성화할 최대 유저 수
-  expireMinutes: 5 # 대기열 유효 시간(분)
+spring:
+  config:
+    activate:
+      on-profile: container
+  datasource:
+    url: jdbc:mysql://mysql:3306/concert
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: hhplus
+    password: 1234
+  data:
+    redis:
+      host: redis
+      port: 6379
+  kafka:
+    bootstrap-servers: kafka:9092
+    consumer:
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
-outbox:
-  scheduler:
-    fixedRate: 60000 # 체크 주기(ms)
-    timeLimitMinutes: 10 # 체크 시간 범위(분)
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: off
+      hibernate.type:
+        descriptor.sql.BasicBinder: off


### PR DESCRIPTION
## 작업 내역

1.	컨테이너 환경에서의 부하 테스트를 위해 Docker Compose 작성

2.	부하 테스트 시나리오를 선정하고, k6를 사용해 테스트를 수행 및 결과를 문서로 작성

<br/>

## 의사결정 흐름

### 1. 부하 테스트 시나리오 구성
- 유저 행동에 가까운 시나리오 2개로 설계:
  - 시나리오 1: 유저 토큰 발급 → 토큰 상태 조회
  - 시나리오 2: 활성화 후 좌석 조회 → 예약 → 결제예약 → 결제 (대량 데이터를 조회하는 반복적인 요청으로 시스템 한계점 확인)

- 테스트 중, 시나리오 2에서 OOM(Out Of Memory) 문제가 발생
  - Redis 캐싱을 적용하려 했으나 RedisException 발생
  - Hikari 커넥션 풀 설정을 조정했으나 타임아웃 문제가 지속적으로 발생
  - 시간 관계상 이 문제는 해결하지 못했지만, 추후 꼭 개선해볼 계획입니다.

### 2.	k6 스크립트 작성
- 사용자 행동 기반의 트래픽을 반영하기 위해 행위 별 함수를 만들고 순차적으로 호출하도록 했습니다.

## 리뷰 포인트

1. Docker Compose와 k6 테스트 스크립트 구성이 적절했는지 궁금합니다.

 